### PR TITLE
Register start and end time

### DIFF
--- a/app.py
+++ b/app.py
@@ -136,8 +136,13 @@ def index():
             startTime = queue[0].endTime
         # If the new reservation would not fit between the current and the first reservation
         else:
-            currentItem = queue[0]
-            nextIndex = 1
+            if current is None:   
+                currentItem = queue[1]
+                nextIndex = 1
+            else:
+                currentItem = current
+                nextIndex = 0
+
             slotFound = False
             queueLength = len(queue)
 

--- a/app.py
+++ b/app.py
@@ -35,11 +35,13 @@ class Reservation:
     def jsonify(self, requestIpAddress):
         timeDelta = self.endTime - datetime.now()
         minutes = timeDelta.days * 24 * 60 * 60 + timeDelta.seconds // 60
+        startTime = self.startTime.strftime("%H:%M")
+        endTime = self.endTime.strftime("%H:%M")
         return {"name": self.name,
             "address": self.ipAddress, 
             "canCancel": self.ipAddress == requestIpAddress,
-            "startTime": self.startTime,
-            "endTime": self.endTime,
+            "startTime": startTime,
+            "endTime": endTime,
             "minutes": minutes,
             "id": self.id}
     def csvify(self):

--- a/app.py
+++ b/app.py
@@ -62,7 +62,7 @@ def UpdateQueueFromFile():
             reader = csv.reader(csvfile, delimiter=';')
             queue.clear()
             for row in reader:
-                if len(row) == 6:
+                if len(row) == 5:
                     name = row[0]
                     ipAddress = row[1]
                     startTime = datetime.strptime(row[2], dateTimeFormat)
@@ -85,6 +85,7 @@ def UpdateFileFromQueue():
 def UpdateCurrentFromQueue():
     global current, queue
     if current is None and len(queue) != 0:
+        queue.sort(key=lambda x: x.startTime)
         potentialCurrent = queue[0]
 
         while potentialCurrent is not None and potentialCurrent.hasPassed():

--- a/app.py
+++ b/app.py
@@ -33,11 +33,14 @@ class Reservation:
     def hasPassed(self):
         return self.endTime <= datetime.now()
     def jsonify(self, requestIpAddress):
+        timeDelta = self.endTime - datetime.now()
+        minutes = timeDelta.days * 24 * 60 * 60 + timeDelta.seconds // 60
         return {"name": self.name,
             "address": self.ipAddress, 
             "canCancel": self.ipAddress == requestIpAddress,
             "startTime": self.startTime,
             "endTime": self.endTime,
+            "minutes": minutes,
             "id": self.id}
     def csvify(self):
         return f"{self.name};{self.ipAddress};{self.startTime.strftime(dateTimeFormat)};{self.endTime.strftime(dateTimeFormat)};{self.id}\n"

--- a/app.py
+++ b/app.py
@@ -35,8 +35,8 @@ class Reservation:
     def jsonify(self, requestIpAddress):
         timeDelta = self.endTime - datetime.now()
         minutes = timeDelta.days * 24 * 60 * 60 + timeDelta.seconds // 60
-        startTime = self.startTime.strftime("%H:%M")
-        endTime = self.endTime.strftime("%H:%M")
+        startTime = self.startTime.strftime(dateTimeFormat)
+        endTime = self.endTime.strftime(dateTimeFormat)
         return {"name": self.name,
             "address": self.ipAddress, 
             "canCancel": self.ipAddress == requestIpAddress,

--- a/app.py
+++ b/app.py
@@ -51,7 +51,12 @@ def UpdateQueueFromFile():
             queue.clear()
             for row in reader:
                 if len(row) == 4:
-                    reservation = Reservation(row[0], row[1], row[2], row[3])
+                    name = row[0]
+                    minutes = row[1]
+                    ipAddress = row[2]
+                    requestId = row[3]
+
+                    reservation = Reservation(name, minutes, ipAddress, requestId)
                     queue.append(reservation)
             UpdateCurrentFromQueue()
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -30,6 +30,8 @@ $(() => {
                 reservationInfo.removeClass("hidden");
                 reservationInfo.find('.name').text(data.name);
                 reservationInfo.find('.time-left').text(data.minutes);
+                reservationInfo.find('.start-time').text(data.startTime);
+                reservationInfo.find('.end-time').text(data.endTime);
                 cancelReservationBtn.data('request-id', data.id);
 
                 if (data.canCancel) {
@@ -71,6 +73,17 @@ $(() => {
                 minutesColumn.data('label', "Minutes left");
                 minutesColumn.text(reservation.minutes);
                 tableRow.append(minutesColumn);
+                
+                var startTimeColumn = $("<td>");
+                startTimeColumn.data('label', "Start time");
+                startTimeColumn.text(reservation.startTime);
+                tableRow.append(startTimeColumn);
+
+                
+                var endTimeColumn = $("<td>");
+                endTimeColumn.data('label', "End time");
+                endTimeColumn.text(reservation.endTime);
+                tableRow.append(endTimeColumn);
 
                 if (reservation.canCancel) {
                     var cancelColumn = $("<td>");

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -29,8 +29,8 @@ $(() => {
                 roomStatus.text("Setup is not available");
                 reservationInfo.removeClass("hidden");
                 reservationInfo.find('.name').text(data.name);
-                reservationInfo.find('.start-time').text(data.startTime);
-                reservationInfo.find('.end-time').text(data.endTime);
+                reservationInfo.find('.start-time').text(convertTimeString(data.startTime));
+                reservationInfo.find('.end-time').text(convertTimeString(data.endTime));
                 reservationInfo.find('.remaining-minutes').text(data.minutes);
                 cancelReservationBtn.data('request-id', data.id);
 
@@ -43,6 +43,16 @@ $(() => {
                 roomStatus.text("Setup is available");
             }
         });
+    }
+    
+    function convertTimeString(timeString) {
+        const date = new Date(timeString);
+        const locale = navigator.language;
+        const formattedTime = new Intl.DateTimeFormat(locale, {
+            timeStyle: "short"
+        }).format(date);
+
+        return formattedTime;
     }
 
     function updateQueue() {
@@ -71,13 +81,13 @@ $(() => {
                 
                 var startTimeColumn = $("<td>");
                 startTimeColumn.data('label', "Start time");
-                startTimeColumn.text(reservation.startTime);
+                startTimeColumn.text(convertTimeString(reservation.startTime));
                 tableRow.append(startTimeColumn);
 
                 
                 var endTimeColumn = $("<td>");
                 endTimeColumn.data('label', "End time");
-                endTimeColumn.text(reservation.endTime);
+                endTimeColumn.text(convertTimeString(reservation.endTime));
                 tableRow.append(endTimeColumn);
 
                 if (reservation.canCancel) {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -29,7 +29,6 @@ $(() => {
                 roomStatus.text("Setup is not available");
                 reservationInfo.removeClass("hidden");
                 reservationInfo.find('.name').text(data.name);
-                reservationInfo.find('.time-left').text(data.minutes);
                 reservationInfo.find('.start-time').text(data.startTime);
                 reservationInfo.find('.end-time').text(data.endTime);
                 cancelReservationBtn.data('request-id', data.id);
@@ -68,11 +67,6 @@ $(() => {
                 nameColumn.data('label', "Name");
                 nameColumn.text(reservation.name);
                 tableRow.append(nameColumn);
-
-                var minutesColumn = $("<td>");
-                minutesColumn.data('label', "Minutes left");
-                minutesColumn.text(reservation.minutes);
-                tableRow.append(minutesColumn);
                 
                 var startTimeColumn = $("<td>");
                 startTimeColumn.data('label', "Start time");

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -31,6 +31,7 @@ $(() => {
                 reservationInfo.find('.name').text(data.name);
                 reservationInfo.find('.start-time').text(data.startTime);
                 reservationInfo.find('.end-time').text(data.endTime);
+                reservationInfo.find('.remaining-minutes').text(data.minutes);
                 cancelReservationBtn.data('request-id', data.id);
 
                 if (data.canCancel) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,12 +24,16 @@
                             <tr>
                                 <th>Name</th>
                                 <th>Minutes left</th>
+                                <th>Start time</th>
+                                <th>End time</th>
                             </tr>
                         </thead>
                         <tbody>
                             <tr>
                                 <td class="name" data-label="Name"></td>
                                 <td class="time-left" data-label="Minutes left"></td>
+                                <td class="start-time" data-label="Start time"></td>
+                                <td class="end-time" data-label="End time"></td>
                             </tr>
                         </tbody>
                     </table>
@@ -63,6 +67,8 @@
                         <tr>
                             <th>Name</th>
                             <th>Minutes left</th>
+                            <th>Start time</th>
+                            <th>End time</th>
                             <th>Action</th>
                         </tr>
                     </thead>

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,6 @@
                         <thead>
                             <tr>
                                 <th>Name</th>
-                                <th>Minutes left</th>
                                 <th>Start time</th>
                                 <th>End time</th>
                             </tr>
@@ -31,7 +30,6 @@
                         <tbody>
                             <tr>
                                 <td class="name" data-label="Name"></td>
-                                <td class="time-left" data-label="Minutes left"></td>
                                 <td class="start-time" data-label="Start time"></td>
                                 <td class="end-time" data-label="End time"></td>
                             </tr>
@@ -66,7 +64,6 @@
                     <thead>
                         <tr>
                             <th>Name</th>
-                            <th>Minutes left</th>
                             <th>Start time</th>
                             <th>End time</th>
                             <th>Action</th>

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,6 +25,7 @@
                                 <th>Name</th>
                                 <th>Start time</th>
                                 <th>End time</th>
+                                <th>Remaining time</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -32,6 +33,7 @@
                                 <td class="name" data-label="Name"></td>
                                 <td class="start-time" data-label="Start time"></td>
                                 <td class="end-time" data-label="End time"></td>
+                                <td class="remaining-minutes" data-label="Remaining minutes"></td>
                             </tr>
                         </tbody>
                     </table>


### PR DESCRIPTION
Partial implemention for #3 
This will not close this issue yet.

This pull-request adds the following functionality:
- Recording start and end time
- Fixed-time reservation. This means, when someone cancels the reservation before you, your reservation doesn't move up
- Automatically inserts the reservation in the first available timeslot

This pull-request does not yet add the ability to select a specific start-time. This will be implemented separately, likely after the refactor for #9 